### PR TITLE
[lspext] Add the lsp extension - 'edefinition'.

### DIFF
--- a/internal/lsp/cmd/serve.go
+++ b/internal/lsp/cmd/serve.go
@@ -120,13 +120,13 @@ func (s *Serve) Run(ctx context.Context, args ...string) error {
 	}
 	// For debugging purposes only.
 	if s.Address != "" {
-		return lsp.RunServerOnAddress(ctx, s.Address, logger)
+		return lsp.RunElasticServerOnAddress(ctx, s.Address, logger)
 	}
 	if s.Port != 0 {
-		return lsp.RunServerOnPort(ctx, s.Port, logger)
+		return lsp.RunElasticServerOnPort(ctx, s.Port, logger)
 	}
 	stream := jsonrpc2.NewHeaderStream(os.Stdin, os.Stdout)
-	return lsp.RunServer(ctx, stream, logger)
+	return lsp.RunElasticServer(ctx, stream, logger)
 }
 
 func (s *Serve) forward() error {

--- a/internal/lsp/elasticext_test.go
+++ b/internal/lsp/elasticext_test.go
@@ -1,0 +1,167 @@
+package lsp
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages/packagestest"
+	"golang.org/x/tools/internal/lsp/cache"
+	"golang.org/x/tools/internal/lsp/protocol"
+	"golang.org/x/tools/internal/lsp/source"
+)
+
+func TestLSPExt(t *testing.T) {
+	packagestest.TestAll(t, testLSPExt)
+}
+
+func testLSPExt(t *testing.T, exporter packagestest.Exporter) {
+	const dir = "testdata"
+
+	// We hardcode the expected number of test cases to ensure that all tests
+	// are being executed. If a test is added, this number must be changed.
+	const expectedQNameKindCount = 36
+	const expectedPkgLocatorCount = 1
+
+	files := packagestest.MustCopyFileTree(dir)
+	for fragment, operation := range files {
+		if trimmed := strings.TrimSuffix(fragment, ".in"); trimmed != fragment {
+			delete(files, fragment)
+			files[trimmed] = operation
+		}
+	}
+	modules := []packagestest.Module{
+		{
+			Name:  "golang.org/x/tools/internal/lsp",
+			Files: files,
+		},
+	}
+	exported := packagestest.Export(t, exporter, modules)
+	defer exported.Cleanup()
+
+	// Merge the exported.Config with the view.Config.
+	cfg := *exported.Config
+	cfg.Fset = token.NewFileSet()
+	cfg.Context = context.Background()
+	cfg.ParseFile = func(fset *token.FileSet, filename string, src []byte) (*ast.File, error) {
+		return parser.ParseFile(fset, filename, src, parser.AllErrors|parser.ParseComments)
+	}
+
+	s := &server{
+		view: cache.NewView(&cfg),
+	}
+	es := &elasticserver{*s}
+
+	expectedQNameKinds := make(qnamekinds)
+	expectedPkgLocators := make(pkgs)
+
+	// Collect any data that needs to be used by subsequent tests.
+	if err := exported.Expect(map[string]interface{}{
+		"packagelocator": expectedPkgLocators.collect,
+		"qnamekind":      expectedQNameKinds.collect,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("QNameKind", func(t *testing.T) {
+		t.Helper()
+		if goVersion111 {
+			if len(expectedQNameKinds) != expectedQNameKindCount {
+				t.Errorf("got %v qnamekinds expected %v", len(expectedQNameKinds), expectedQNameKindCount)
+			}
+		}
+		expectedQNameKinds.test(t, es)
+	})
+
+	t.Run("PKG", func(t *testing.T) {
+		t.Helper()
+		if goVersion111 {
+			if len(expectedPkgLocators) != expectedPkgLocatorCount {
+				t.Errorf("got %v pkgs expected %v", len(expectedPkgLocators), expectedPkgLocatorCount)
+			}
+		}
+		expectedPkgLocators.test(t, es)
+	})
+}
+
+type QNameKindResult struct {
+	Qname string
+	Kind  int64
+}
+
+type PkgResultTuple struct {
+	PkgName string
+	RepoURI string
+}
+
+type qnamekinds map[protocol.Location]QNameKindResult
+type pkgs map[protocol.Location]PkgResultTuple
+
+func (qk qnamekinds) test(t *testing.T, s *elasticserver) {
+	for src, target := range qk {
+		params := &protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{
+				URI: src.URI,
+			},
+			Position: src.Range.Start,
+		}
+		var locs []protocol.SymbolLocator
+		var err error
+		locs, err = s.EDefinition(context.Background(), params)
+		if err != nil {
+			t.Fatalf("failed for %s: %v", src, err)
+		}
+		if len(locs) != 1 {
+			t.Errorf("got %d locations for qnamekind, expected 1", len(locs))
+		}
+
+		if locs[0].Qname != target.Qname {
+			t.Errorf("Qname: for %v got %v want %v", src, locs[0].Qname, target.Qname)
+		}
+
+		if locs[0].Kind != protocol.SymbolKind(target.Kind) {
+			t.Errorf("Kind: for %v got %v want %v", src, locs[0].Kind, target.Kind)
+		}
+	}
+}
+
+func (qk qnamekinds) collect(fset *token.FileSet, src packagestest.Range, qname string, kind int64) {
+	loc := toProtocolLocation(fset, source.Range(src))
+	qk[loc] = QNameKindResult{Qname: qname, Kind: kind}
+}
+
+func (ps pkgs) test(t *testing.T, s *elasticserver) {
+	for src, target := range ps {
+		params := &protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{
+				URI: src.URI,
+			},
+			Position: src.Range.Start,
+		}
+		var locs []protocol.SymbolLocator
+		var err error
+		locs, err = s.EDefinition(context.Background(), params)
+		if err != nil {
+			t.Fatalf("failed for %s: %v", src, err)
+		}
+		if len(locs) != 1 {
+			t.Errorf("got %d locations for package locators, expected 1", len(locs))
+		}
+
+		if locs[0].Package.Name != target.PkgName {
+			t.Errorf("PkgName: for %v got %v want %v", src, locs[0].Package.Name, target.PkgName)
+		}
+
+		if locs[0].Package.RepoURI != target.RepoURI {
+			t.Errorf("PkgRepoURI: for %v got %v want %v", src, locs[0].Package.RepoURI, target.RepoURI)
+		}
+	}
+}
+
+func (ps pkgs) collect(fset *token.FileSet, src packagestest.Range, pkgname, repouri string) {
+	loc := toProtocolLocation(fset, source.Range(src))
+	ps[loc] = PkgResultTuple{PkgName: pkgname, RepoURI: repouri}
+}

--- a/internal/lsp/elasticserver.go
+++ b/internal/lsp/elasticserver.go
@@ -1,0 +1,262 @@
+package lsp
+
+import (
+	"context"
+	"fmt"
+	"go/ast"
+	"go/types"
+	"net"
+	"strings"
+
+	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/internal/jsonrpc2"
+	"golang.org/x/tools/internal/lsp/protocol"
+	"golang.org/x/tools/internal/lsp/source"
+)
+
+// RunElasticServer starts an LSP server on the supplied stream, and waits until the
+// stream is closed.
+func RunElasticServer(ctx context.Context, stream jsonrpc2.Stream, opts ...interface{}) error {
+	s := &elasticserver{}
+	conn, client := protocol.RunElasticServer(ctx, stream, s, opts...)
+	s.client = client
+	return conn.Wait(ctx)
+}
+
+// RunElasticServerOnPort starts an LSP server on the given port and does not exit.
+// This function exists for debugging purposes.
+func RunElasticServerOnPort(ctx context.Context, port int, opts ...interface{}) error {
+	return RunElasticServerOnAddress(ctx, fmt.Sprintf(":%v", port))
+}
+
+// RunElasticServerOnAddress starts an LSP server on the given port and does not exit.
+// This function exists for debugging purposes.
+func RunElasticServerOnAddress(ctx context.Context, addr string, opts ...interface{}) error {
+	s := &elasticserver{}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return err
+		}
+		stream := jsonrpc2.NewHeaderStream(conn, conn)
+		go func() {
+			conn, client := protocol.RunElasticServer(ctx, stream, s, opts...)
+			s.client = client
+			conn.Wait(ctx)
+		}()
+	}
+}
+
+// elasticserver "inherits" from lsp.server and is used to implement the elastic extention for the official go lsp.
+type elasticserver struct {
+	server
+}
+
+// EDefinition has almost the same functionality with Definition except for the qualified name and symbol kind.
+func (s *elasticserver) EDefinition(ctx context.Context, params *protocol.TextDocumentPositionParams) ([]protocol.SymbolLocator, error) {
+	sourceURI, err := fromProtocolURI(params.TextDocument.URI)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := s.view.GetFile(ctx, sourceURI)
+	if err != nil {
+		return nil, err
+	}
+	tok := f.GetToken(ctx)
+
+	// Note GetToken may return nil, check the return value before the access. See https://github.com/golang/go/issues/30562
+	if tok == nil {
+		return nil, fmt.Errorf("no token files found for this file")
+	}
+
+	pos := fromProtocolPosition(tok, params.Position)
+	ident, err := source.Identifier(ctx, s.view, f, pos)
+	if err != nil {
+		return nil, err
+	}
+
+	kind := getSymbolKind(ident)
+	if kind == 0 {
+		return nil, fmt.Errorf("no corresponding symbol kind for '" + ident.Name + "'")
+	}
+
+	qname := getQName(ctx, f, ident, kind)
+
+	// Get the package where the symbol belongs to.
+	pkg := ident.Declaration.Object.Pkg()
+	if pkg == nil {
+		return nil, fmt.Errorf("no packages found for the identifier")
+	}
+
+	var pkgLoc protocol.PackageLocator
+	if pkg.Name() != f.GetPackage(ctx).Name {
+		// Handle the case where symbols imported from other packages.
+		var pkgPath string
+
+		for _, p := range f.GetPackage(ctx).Imports {
+			if p.Name == pkg.Name() {
+				pkgPath = p.PkgPath
+				break
+			}
+		}
+
+		pkgLoc = protocol.PackageLocator{Name: pkg.Name(), RepoURI: string(pkgPath)}
+	} else {
+		pkgLoc = protocol.PackageLocator{Name: pkg.Name(), RepoURI: string(f.GetPackage(ctx).PkgPath)}
+	}
+
+	loc := toProtocolLocation(s.view.FileSet(), ident.Declaration.Range)
+
+	path := strings.TrimPrefix(string(sourceURI), "file://")
+
+	return []protocol.SymbolLocator{{Qname: qname, Kind: kind, Path: path, Loc: loc, Package: pkgLoc}}, nil
+}
+
+// getSymbolKind get the symbol kind for a single position.
+// TODO(henrywong) Once the upstream implement the ‘textDocument/documentSymbol’, we should reconsider this method.
+//  Like if we cache all the symbols in a document when we handle the document symbol request, we can get the symbol
+//  information from the cache directly.
+func getSymbolKind(ident *source.IdentifierInfo) protocol.SymbolKind {
+	declObj := ident.Declaration.Object
+	switch declObj.(type) {
+	case *types.Const:
+		return protocol.ConstantSymbol
+	case *types.Var:
+		v, _ := declObj.(*types.Var)
+		if v.IsField() {
+			return protocol.FieldSymbol
+		}
+		return protocol.VariableSymbol
+	case *types.Nil:
+		return protocol.NullSymbol
+	case *types.PkgName:
+		return protocol.PackageSymbol
+	case *types.Func:
+		s, _ := declObj.Type().(*types.Signature)
+		if s.Recv() == nil {
+			return protocol.FunctionSymbol
+		}
+		return protocol.MethodSymbol
+	case *types.TypeName:
+		tyObj := ident.Type.Object
+		if tyObj != nil {
+			namedTy := tyObj.Type().(*types.Named)
+			switch namedTy.Underlying().(type) {
+			case *types.Struct:
+				return protocol.StructSymbol
+			case *types.Interface:
+				return protocol.InterfaceSymbol
+			}
+		}
+	}
+
+	return protocol.SymbolKind(0)
+}
+
+// getQName returns the qualified name for a position in a file. Qualied name mainly served as the cross repo code
+// search and code intelligence. The qualified name pattern as bellow:
+//  qname = package.name + struct.name* + function.name* | (struct.name + method.name)* + struct.name* + symbol.name
+//
+// TODO(henrywong) It's better to use the scope chain to give a qualifed name for the symbols, however there is no
+// APIs can achieve this goals, just traverse the ast node path for now.
+func getQName(ctx context.Context, f source.File, ident *source.IdentifierInfo, kind protocol.SymbolKind) string {
+	declObj := ident.Declaration.Object
+	qname := declObj.Name()
+
+	if kind == protocol.PackageSymbol {
+		return qname
+	}
+
+	// Get the file where the symbol definition located.
+	fAST := f.GetAST(ctx)
+	pos := declObj.Pos()
+	path, _ := astutil.PathEnclosingInterval(fAST, pos, pos)
+
+	// TODO(henrywong) Should we put a check here for the case of only one node?
+	for id, n := range path[1:] {
+		switch n.(type) {
+		case *ast.StructType:
+			// Check its father to decide whether the ast.StructType is a named type or an anonymous type.
+			switch path[id+2].(type) {
+			case *ast.TypeSpec:
+				// ident is located in a named struct declaration, add the type name into the qualified name.
+				ts, _ := path[id+2].(*ast.TypeSpec)
+				qname = ts.Name.Name + "." + qname
+			case *ast.Field:
+				// ident is located in a anonymous struct declaration which used to define a field, like struct fields,
+				// function parameters, function named return parameters, add the field name into the qualifed name.
+				field, _ := path[id+2].(*ast.Field)
+				if len(field.Names) != 0 {
+					// If there is a bunch of fields declared with same anonymous struct type, just consider the first field's
+					// name.
+					qname = field.Names[0].Name + "." + qname
+				}
+
+			case *ast.ValueSpec:
+				// ident is located in a anonymous struct decalaration which used define a variable, add the variable name into
+				// the qualifed name.
+				vs, _ := path[id+2].(*ast.ValueSpec)
+				if len(vs.Names) != 0 {
+					// If there is a bunch of variables declared with same anonymous struct type, just consider the first
+					// variable's name.
+					qname = vs.Names[0].Name + "." + qname
+				}
+			}
+		case *ast.InterfaceType:
+			// Check its father to get the interface name.
+			switch path[id+2].(type) {
+			case *ast.TypeSpec:
+				ts, _ := path[id+2].(*ast.TypeSpec)
+				qname = ts.Name.Name + "." + qname
+			}
+
+		case *ast.FuncDecl:
+			f, _ := n.(*ast.FuncDecl)
+			if f.Name != nil && f.Name.Name != qname && (kind == protocol.MethodSymbol || kind == protocol.FunctionSymbol) {
+				qname = f.Name.Name + "." + qname
+			}
+
+			if f.Name != nil {
+				if kind == protocol.MethodSymbol || kind == protocol.FunctionSymbol {
+					if f.Name.Name != qname {
+						qname = f.Name.Name + "." + qname
+					}
+				} else {
+					qname = f.Name.Name + "." + qname
+				}
+			}
+
+			// If n is method, add the struct name as a prefix.
+			if f.Recv != nil {
+				var typeName string
+				switch r := f.Recv.List[0].Type.(type) {
+				case *ast.StarExpr:
+					typeName = r.X.(*ast.Ident).Name
+				case *ast.Ident:
+					typeName = r.Name
+				}
+				qname = typeName + "." + qname
+			}
+		case *ast.FuncLit:
+			// Considering the function literal is for making the local variable declared in it more unique, the handling is
+			// a little tricky. If the function literal is assigned to a named entity, like variable, it is better consider
+			// the variable name into the qualified name.
+
+			// Check its ancestors to decide where it is located in, like a assignment, variable declaration, or a return
+			// statement.
+			switch path[id+2].(type) {
+			case *ast.AssignStmt:
+				as, _ := path[id+2].(*ast.AssignStmt)
+				if i, ok := as.Lhs[0].(*ast.Ident); ok {
+					qname = i.Name + "." + qname
+				}
+			}
+		}
+	}
+	return declObj.Pkg().Name() + "." + qname
+}

--- a/internal/lsp/protocol/elasticext.go
+++ b/internal/lsp/protocol/elasticext.go
@@ -1,0 +1,21 @@
+package protocol
+
+type PackageLocator struct {
+	Name    string
+	RepoURI string `json:"uri"`
+}
+
+// SymbolLocator is the response type for the `textDocument/edefinition` extension.
+type SymbolLocator struct {
+	// The fully qualified name of the symbol.
+	Qname string
+
+	Kind SymbolKind
+
+	Path string
+
+	// A concrete location at which the definition is located.
+	Loc Location `json:"location,omitempty"`
+
+	Package PackageLocator
+}

--- a/internal/lsp/protocol/elasticserver.go
+++ b/internal/lsp/protocol/elasticserver.go
@@ -1,0 +1,366 @@
+package protocol
+
+import (
+	"context"
+	"encoding/json"
+
+	"golang.org/x/tools/internal/jsonrpc2"
+)
+
+type ElasticServer interface {
+	Server
+	EDefinition(context.Context, *TextDocumentPositionParams) ([]SymbolLocator, error)
+}
+
+func elasticServerHandler(server ElasticServer) jsonrpc2.Handler {
+	return func(ctx context.Context, conn *jsonrpc2.Conn, r *jsonrpc2.Request) {
+		switch r.Method {
+		case "initialize":
+			var params InitializeParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.Initialize(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "initialized":
+			var params InitializedParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			unhandledError(server.Initialized(ctx, &params))
+
+		case "shutdown":
+			if r.Params != nil {
+				conn.Reply(ctx, r, nil, jsonrpc2.NewErrorf(jsonrpc2.CodeInvalidParams, "Expected no params"))
+				return
+			}
+			unhandledError(server.Shutdown(ctx))
+
+		case "exit":
+			if r.Params != nil {
+				conn.Reply(ctx, r, nil, jsonrpc2.NewErrorf(jsonrpc2.CodeInvalidParams, "Expected no params"))
+				return
+			}
+			unhandledError(server.Exit(ctx))
+
+		case "$/cancelRequest":
+			var params CancelParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			conn.Cancel(params.ID)
+
+		case "workspace/didChangeWorkspaceFolders":
+			var params DidChangeWorkspaceFoldersParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			unhandledError(server.DidChangeWorkspaceFolders(ctx, &params))
+
+		case "workspace/didChangeConfiguration":
+			var params DidChangeConfigurationParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			unhandledError(server.DidChangeConfiguration(ctx, &params))
+
+		case "workspace/didChangeWatchedFiles":
+			var params DidChangeWatchedFilesParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			unhandledError(server.DidChangeWatchedFiles(ctx, &params))
+
+		case "workspace/symbol":
+			var params WorkspaceSymbolParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.Symbols(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "workspace/executeCommand":
+			var params ExecuteCommandParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.ExecuteCommand(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/didOpen":
+			var params DidOpenTextDocumentParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			unhandledError(server.DidOpen(ctx, &params))
+
+		case "textDocument/didChange":
+			var params DidChangeTextDocumentParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			unhandledError(server.DidChange(ctx, &params))
+
+		case "textDocument/willSave":
+			var params WillSaveTextDocumentParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			unhandledError(server.WillSave(ctx, &params))
+
+		case "textDocument/willSaveWaitUntil":
+			var params WillSaveTextDocumentParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.WillSaveWaitUntil(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/didSave":
+			var params DidSaveTextDocumentParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			unhandledError(server.DidSave(ctx, &params))
+
+		case "textDocument/didClose":
+			var params DidCloseTextDocumentParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			unhandledError(server.DidClose(ctx, &params))
+
+		case "textDocument/completion":
+			var params CompletionParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.Completion(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "completionItem/resolve":
+			var params CompletionItem
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.CompletionResolve(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/hover":
+			var params TextDocumentPositionParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.Hover(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/signatureHelp":
+			var params TextDocumentPositionParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.SignatureHelp(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/definition":
+			var params TextDocumentPositionParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.Definition(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/edefinition":
+			var params TextDocumentPositionParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.EDefinition(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/typeDefinition":
+			var params TextDocumentPositionParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.TypeDefinition(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/implementation":
+			var params TextDocumentPositionParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.Implementation(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/references":
+			var params ReferenceParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.References(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/documentHighlight":
+			var params TextDocumentPositionParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.DocumentHighlight(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/documentSymbol":
+			var params DocumentSymbolParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.DocumentSymbol(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/codeAction":
+			var params CodeActionParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.CodeAction(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/codeLens":
+			var params CodeLensParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.CodeLens(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "codeLens/resolve":
+			var params CodeLens
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.CodeLensResolve(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/documentLink":
+			var params DocumentLinkParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.DocumentLink(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "documentLink/resolve":
+			var params DocumentLink
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.DocumentLinkResolve(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/documentColor":
+			var params DocumentColorParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.DocumentColor(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/colorPresentation":
+			var params ColorPresentationParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.ColorPresentation(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/formatting":
+			var params DocumentFormattingParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.Formatting(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/rangeFormatting":
+			var params DocumentRangeFormattingParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.RangeFormatting(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/onTypeFormatting":
+			var params DocumentOnTypeFormattingParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.OnTypeFormatting(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/rename":
+			var params RenameParams
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.Rename(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+
+		case "textDocument/foldingRange":
+			var params FoldingRangeRequestParam
+			if err := json.Unmarshal(*r.Params, &params); err != nil {
+				sendParseError(ctx, conn, r, err)
+				return
+			}
+			resp, err := server.FoldingRanges(ctx, &params)
+			unhandledError(conn.Reply(ctx, r, resp, err))
+		default:
+			if r.IsNotify() {
+				conn.Reply(ctx, r, nil, jsonrpc2.NewErrorf(jsonrpc2.CodeMethodNotFound, "method %q not found", r.Method))
+			}
+		}
+	}
+}
+
+func RunElasticServer(ctx context.Context, stream jsonrpc2.Stream, server ElasticServer, opts ...interface{}) (*jsonrpc2.Conn, Client) {
+	opts = append([]interface{}{elasticServerHandler(server), jsonrpc2.Canceler(canceller)}, opts...)
+	conn := jsonrpc2.NewConn(ctx, stream, opts...)
+	return conn, &clientDispatcher{Conn: conn}
+}

--- a/internal/lsp/testdata/lspext/packagelocator.go
+++ b/internal/lsp/testdata/lspext/packagelocator.go
@@ -1,0 +1,14 @@
+package edefinition
+
+import (
+	"fmt"
+
+	"golang.org/x/tools/internal/jsonrpc2"
+)
+
+// There is a bug in this test framework that it can't get the identifier from the imports nonofficial package in the
+// test process. Like can get the identifier 'Println' from "fmt", but can't get the identifier 'Direction' from 'jsonrpc2'.
+func pkgloc() { //@packagelocator("loc", "edefinition", "golang.org/x/tools/internal/lsp/lspext")
+	var d jsonrpc2.Direction // bug, packagelocator("Dir", "jsonrpc2", "golang.org/x/tools/internal/jsonrpc2")
+	fmt.Println(d.String())  // bug, packagelocator("tring", "jsonrpc2", "golang.org/x/tools/internal/jsonrpc2")
+}

--- a/internal/lsp/testdata/lspext/qnamekind.go
+++ b/internal/lsp/testdata/lspext/qnamekind.go
@@ -1,0 +1,190 @@
+package edefinition //Test fail here, edefinition("def", "edefinition", 4)
+
+import (
+	"fmt"
+)
+
+// FileSymbol          SymbolKind = 1
+// ModuleSymbol        SymbolKind = 2
+// NamespaceSymbol     SymbolKind = 3
+// PackageSymbol       SymbolKind = 4
+// ClassSymbol         SymbolKind = 5
+// MethodSymbol        SymbolKind = 6
+// PropertySymbol      SymbolKind = 7
+// FieldSymbol         SymbolKind = 8
+// ConstructorSymbol   SymbolKind = 9
+// EnumSymbol          SymbolKind = 10
+// InterfaceSymbol     SymbolKind = 11
+// FunctionSymbol      SymbolKind = 12
+// VariableSymbol      SymbolKind = 13
+// ConstantSymbol      SymbolKind = 14
+// StringSymbol        SymbolKind = 15
+// NumberSymbol        SymbolKind = 16
+// BooleanSymbol       SymbolKind = 17
+// ArraySymbol         SymbolKind = 18
+// ObjectSymbol        SymbolKind = 19
+// KeySymbol           SymbolKind = 20
+// NullSymbol          SymbolKind = 21
+// EnumMemberSymbol    SymbolKind = 22
+// StructSymbol        SymbolKind = 23
+// EventSymbol         SymbolKind = 24
+// OperatorSymbol      SymbolKind = 25
+// TypeParameterSymbol SymbolKind = 26
+
+// Note: '@qnamekind("first", "second", number)', means check the location where the first element located, the second
+// element represents the qualified name, the third element represents the symbol kind.
+
+// Test struct declaration and the field declarations.
+type Circle struct { //@qnamekind("cle", "edefinition.Circle", 23)
+	r    float64  //@qnamekind("r", "edefinition.Circle.r", 8)
+	Node struct { //@qnamekind("e", "edefinition.Circle.Node", 8)
+		x int //@qnamekind("x", "edefinition.Circle.Node.x", 8)
+		y int
+	}
+}
+
+// Test function declaration and variables.
+func func1() int { //@qnamekind("c1", "edefinition.func1", 12)
+	lhs := 10          //@qnamekind("lhs", "edefinition.func1.lhs", 13)
+	const rhs int = 20 //@qnamekind("rhs", "edefinition.func1.rhs", 14)
+	return lhs + rhs   //@qnamekind("rhs", "edefinition.func1.rhs", 14)
+}
+
+// Test method declaration and field access.
+func (c *Circle) method1() { //edefinition("method1", "edefinition.Circle.method1", 6)
+	fmt.Print(c.r) //@qnamekind("fmt", "fmt", 4),qnamekind("Pri", "fmt.Print", 12)
+
+	fmt.Print(c.Node.x) //@qnamekind("No", "edefinition.Circle.Node", 8)
+}
+
+// Test the interface declaration and method declaration.
+type Shape interface { //@qnamekind("ha", "edefinition.Shape", 11)
+	Area() int //@qnamekind("Are", "edefinition.Shape.Area", 6)
+}
+
+// Test method call and the variabel declaration in a nested scope.
+func func2() {
+	var c Circle //@qnamekind("c", "edefinition.func2.c", 13)
+	c.method1()  //@qnamekind("meth", "edefinition.Circle.method1", 6),qnamekind("c", "edefinition.func2.c", 13)
+
+	{
+		num := 20 //@qnamekind("num", "edefinition.func2.num", 13)
+		fmt.Println(num)
+	}
+}
+
+// Test the struct declared in a function.
+func structInFunc() {
+	type A struct { //@qnamekind("A", "edefinition.structInFunc.A", 23)
+		x int //@qnamekind("x", "edefinition.structInFunc.A.x", 8)
+		y int
+	}
+
+	a := &A{x: 10, y: 20} //@qnamekind("x", "edefinition.structInFunc.A.x", 8)
+	fmt.Println(a.x, a.y)
+}
+
+// Test the named structs which have the same name and declared in different scopes.
+func structInAnonyScopes() {
+	{
+		type A struct { //@qnamekind("A", "edefinition.structInAnonyScopes.A", 23)
+			x int //@qnamekind("x", "edefinition.structInAnonyScopes.A.x", 8)
+		}
+
+		a := &A{x: 10} //@qnamekind("A", "edefinition.structInAnonyScopes.A", 23)
+		fmt.Println(a)
+	}
+
+	{
+		type A struct { //@qnamekind("A", "edefinition.structInAnonyScopes.A", 23)
+			x int
+		}
+
+		a := &A{x: 10} //@qnamekind("A", "edefinition.structInAnonyScopes.A", 23)
+		fmt.Println(a)
+	}
+}
+
+// Test the local vatiable declared in the method declaration.
+func (c *Circle) method2() {
+	num := 10        //@qnamekind("nu", "edefinition.Circle.method2.num", 13)
+	fmt.Println(num) //@qnamekind("Pri", "fmt.Println", 12)
+}
+
+// Test the field located in a struct which declared in a method declaration.
+func (c *Circle) method3() {
+	type Rectangle struct {
+		x int
+		y int //@qnamekind("y", "edefinition.Circle.method3.Rectangle.y", 8)
+	}
+}
+
+// Test the variable declared in an anonymous functions case#1.
+func func4() {
+	f := func(x int) int {
+		num := 10 //@qnamekind("num", "edefinition.func4.f.num", 13)
+		return x + num
+	}
+	fmt.Println(f(1))
+}
+
+// Test the variable declared in an anonymous functions case#2.
+func func5() func(int) int {
+	return func(x int) int {
+		num := 10 //@qnamekind("nu", "edefinition.func5.num", 13)
+		return x + num
+	}
+}
+
+// Test the variable declared in an anonymous functions case#3.
+func func6() (f func(int) int) {
+	f = func(x int) int {
+		num := 10 //@qnamekind("n", "edefinition.func6.f.num", 13)
+		return x + num
+	}
+	return
+}
+
+// Test the field symbol in an anonymous type case#1.
+func func7() {
+	var node struct {
+		x int //@qnamekind("x", "edefinition.func7.node.x", 8)
+		y int
+	}
+	fmt.Println(node)
+}
+
+// Test the field symbol in an anonymous type case#2.
+func func8(pair struct {
+	x int //@qnamekind("x", "edefinition.func8.pair.x", 8)
+	y int
+}) int {
+	return pair.x + pair.y
+}
+
+// Test the field symbol in an anonymous type case#3
+func func9(x int, y int) (pair struct { //@edefinition("x", "edefinition.func9.x", 13)
+	x int //@qnamekind("x", "edefinition.func9.pair.x", 8)
+	y int
+}) {
+	pair.x = x
+	pair.y = y
+	return
+}
+
+// Test the field symbol in a anonymous type case#4
+func func10() {
+	// In this case just consider the first variable's name.
+	var node1, node2 struct {
+		x int //@qnamekind("x", "edefinition.func10.node1.x", 8)
+		y int
+	}
+	fmt.Println(node1)
+	fmt.Println(node2)
+}
+
+// Test the named return parameters.
+func func11(lhs int, rhs int) (sum int) { //@qnamekind("su", "edefinition.func11.sum", 13)
+	sum = lhs + rhs
+	return
+}


### PR DESCRIPTION
The extension 'definition' needs to compute qname, package locator and
symbol kind.

The 'packages.Load()' method can't resolve the packages located
outside the '$GOPATH/src', except the path is not the relative path,
sourcegraph and the vscode-go both have this problem.