### PR TITLE
[elastic] NFC: Sync to the upstream changes.

### DIFF
--- a/internal/lsp/elasticext_test.go
+++ b/internal/lsp/elasticext_test.go
@@ -24,7 +24,7 @@ func testLSPExt(t *testing.T, exporter packagestest.Exporter) {
 	// We hardcode the expected number of test cases to ensure that all tests
 	// are being executed. If a test is added, this number must be changed.
 	const expectedQNameKindCount = 36
-	const expectedPkgLocatorCount = 1
+	const expectedPkgLocatorCount = 2
 
 	files := packagestest.MustCopyFileTree(dir)
 	for fragment, operation := range files {

--- a/internal/lsp/protocol/elasticserver.go
+++ b/internal/lsp/protocol/elasticserver.go
@@ -344,7 +344,7 @@ func elasticServerHandler(server ElasticServer) jsonrpc2.Handler {
 			unhandledError(conn.Reply(ctx, r, resp, err))
 
 		case "textDocument/foldingRange":
-			var params FoldingRangeRequestParam
+			var params FoldingRangeParams
 			if err := json.Unmarshal(*r.Params, &params); err != nil {
 				sendParseError(ctx, conn, r, err)
 				return

--- a/internal/lsp/testdata/lspext/packagelocator.go
+++ b/internal/lsp/testdata/lspext/packagelocator.go
@@ -10,5 +10,5 @@ import (
 // test process. Like can get the identifier 'Println' from "fmt", but can't get the identifier 'Direction' from 'jsonrpc2'.
 func pkgloc() { //@packagelocator("loc", "edefinition", "golang.org/x/tools/internal/lsp/lspext")
 	var d jsonrpc2.Direction // bug, packagelocator("Dir", "jsonrpc2", "golang.org/x/tools/internal/jsonrpc2")
-	fmt.Println(d.String())  // bug, packagelocator("tring", "jsonrpc2", "golang.org/x/tools/internal/jsonrpc2")
+	fmt.Println(d.String())  //@packagelocator("rintln", "fmt", "fmt")
 }


### PR DESCRIPTION
There are several API breaks of upstream changes, update the code accordingly.

This commit also fixes an inefficiency issue when collecting the package locator
information.