### PR TITLE
[elastic] Fix the jsonrpc2 panic bug imported by previous commits.

### DIFF
--- a/internal/lsp/elasticserver.go
+++ b/internal/lsp/elasticserver.go
@@ -26,7 +26,7 @@ func RunElasticServer(ctx context.Context, stream jsonrpc2.Stream, opts ...inter
 // RunElasticServerOnPort starts an LSP server on the given port and does not exit.
 // This function exists for debugging purposes.
 func RunElasticServerOnPort(ctx context.Context, port int, opts ...interface{}) error {
-	return RunElasticServerOnAddress(ctx, fmt.Sprintf(":%v", port), opts)
+	return RunElasticServerOnAddress(ctx, fmt.Sprintf(":%v", port))
 }
 
 // RunElasticServerOnAddress starts an LSP server on the given port and does not exit.


### PR DESCRIPTION
The `opts` argument should not be passed to the jsonrpc2, that will
trigger an unrecognized option type error. In contrast, the parameter 
`opts` of `RunElasticServerOnPort` is an unused parameter, I will file
an issue on `golang/tools` latter.