### PR TITLE
[elastic] Manage the deps.

### DIFF
--- a/internal/lsp/protocol/elasticserver.go
+++ b/internal/lsp/protocol/elasticserver.go
@@ -3,9 +3,14 @@ package protocol
 import (
 	"context"
 	"encoding/json"
-	"golang.org/x/tools/internal/lsp/xlog"
-
 	"golang.org/x/tools/internal/jsonrpc2"
+	"golang.org/x/tools/internal/lsp/xlog"
+	"golang.org/x/tools/internal/span"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 )
 
 type ElasticServer interface {
@@ -22,6 +27,10 @@ func elasticServerHandler(log xlog.Logger, server ElasticServer) jsonrpc2.Handle
 				sendParseError(ctx, log, conn, r, err)
 				return
 			}
+			if err := manageDeps(&params); err != nil {
+				log.Errorf(ctx, "%v", err)
+			}
+
 			resp, err := server.Initialize(ctx, &params)
 			if err := conn.Reply(ctx, r, resp, err); err != nil {
 				log.Errorf(ctx, "%v", err)
@@ -445,4 +454,166 @@ func NewElasticServer(stream jsonrpc2.Stream, server ElasticServer) (*jsonrpc2.C
 	conn.Handler = elasticServerHandler(log, server)
 	conn.Canceler = jsonrpc2.Canceler(canceller)
 	return conn, client, log
+}
+
+type RepoMeta struct {
+	rootURI       span.URI
+	moduleFolders []string
+}
+
+// manageDeps will explore the repo and give a whole picture of it. Besides that, manageDeps will try its best to
+// convert the repo to modules. The core functions of deps downloading and deps management will be assumed by
+// the package 'cache'.
+func manageDeps(params *InitializeParams) error {
+	metadata := &RepoMeta{}
+	if params.RootURI != "" {
+		metadata.rootURI = span.NewURI(params.RootURI)
+	}
+
+	if err := collectMetadata(metadata); err != nil {
+		return err
+	}
+
+	var folders []WorkspaceFolder
+	// Convert the module folders to the workspace folders.
+	for _, folder := range metadata.moduleFolders {
+		uri := span.NewURI(folder)
+
+		alreadyIn := false
+		for _, wf := range params.WorkspaceFolders {
+			if filepath.Clean(string(uri)) == filepath.Clean(wf.URI) {
+				alreadyIn = true
+			}
+		}
+
+		if !alreadyIn {
+			folders = append(folders, WorkspaceFolder{URI: string(uri), Name: filepath.Base(folder)})
+		}
+	}
+
+	params.WorkspaceFolders = append(params.WorkspaceFolders, folders...)
+	return nil
+}
+
+// collectMetadata explores the repo to collects the meta information of the repo. And create a new 'go.mod' if
+// necessary to cover all the source files.
+func collectMetadata(metadata *RepoMeta) error {
+	rootPath, _ := metadata.rootURI.Filename()
+
+	// Collect 'go.mod' and record them as workspace folders.
+	if err := filepath.Walk(rootPath, func(path string, info os.FileInfo, err error) error {
+		if info.Name()[0] == '.' {
+			return filepath.SkipDir
+		} else if info.Name() == "go.mod" {
+			dir := filepath.Dir(path)
+			metadata.moduleFolders = append(metadata.moduleFolders, dir)
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	folderUncovered, folderNeedMod, err := collectUncoveredSrc(rootPath)
+	if err != nil {
+		return nil
+	}
+
+	// If folders need to be covered exist, a new 'go.mod' will be created manually.
+	if len(folderUncovered) > 0 {
+		longestPrefix := string(filepath.Separator)
+		// Compute the longest common prefix of the folders which need to be covered by 'go.mod'.
+	DONE:
+		for i, name := range folderUncovered[0] {
+			same := true
+			for _, folder := range folderUncovered[1:] {
+				if len(folder) < i || folder[i] != name {
+					same = false
+					break DONE
+				}
+			}
+
+			if same {
+				longestPrefix = filepath.Join(longestPrefix, name)
+			}
+		}
+
+		folderNeedMod = append(folderNeedMod, filepath.Clean(longestPrefix))
+	}
+
+	for _, path := range folderNeedMod {
+		cmd := exec.Command("go", "mod", "init", path)
+		cmd.Dir = path
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+		metadata.moduleFolders = append(metadata.moduleFolders, path)
+	}
+
+	return nil
+}
+
+// existDepControlFile determines if dependence control files exist in the specified folder.
+func existDepControlFile(dir string) bool {
+	var Converters = []string{
+		"GLOCKFILE",
+		"Godeps/Godeps.json",
+		"Gopkg.lock",
+		"dependencies.tsv",
+		"glide.lock",
+		"vendor.conf",
+		"vendor.yml",
+		"vendor/manifest",
+		"vendor/vendor.json",
+	}
+
+	for _, name := range Converters {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// collectUncoveredSrc explores the rootPath recursively, collects
+//  - folders need to be covered, which we will create a module to cover all these folders.
+//  - folders need to create a module.
+func collectUncoveredSrc(path string) ([][]string, []string, error) {
+	var folderUncovered [][]string
+	var folderNeedMod []string
+
+	if _, err := os.Stat(filepath.Join(path, "go.mod")); err == nil {
+		return nil, nil, nil
+	}
+
+	if existDepControlFile(path) {
+		folderNeedMod = append(folderNeedMod, path)
+		return nil, folderNeedMod, nil
+	}
+
+	// If there are remaining '.go' source files under the current folder, that means they will not be covered by
+	// any 'go.mod'.
+	shouldBeCovered := false
+	fileInfo, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, info := range fileInfo {
+		if !shouldBeCovered && filepath.Ext(info.Name()) == ".go" && !strings.HasSuffix(info.Name(), "_test.go") {
+			shouldBeCovered = true
+		}
+
+		if info.IsDir() && info.Name()[0] != '.' {
+			uncovered, mod, e := collectUncoveredSrc(filepath.Join(path, info.Name()))
+			folderNeedMod = append(folderNeedMod, mod...)
+			folderUncovered = append(folderUncovered, uncovered...)
+			err = e
+		}
+	}
+
+	if shouldBeCovered {
+		folderUncovered = append(folderUncovered, strings.Split(path, string(filepath.Separator)))
+	}
+
+	return folderUncovered, folderNeedMod, err
 }


### PR DESCRIPTION
This is the initial commit of deps management. Considering the
consistency and the implementation, use the '$GOPATH/pkg/mod', which is
the default location to hold the module deps, to store the deps.

Use a specified folder under '.../kibana/data/code' is difficult to
implement, we have to adjust the package resolve mechanism
correspondingly. Another option, i.e. creating the 'vendor' folder in
every repo has several drawbacks as below:
 - Storage waste
 - Append every go command, mainly `go list`, with `-mod=vendor`. And we
   need to expand initialize options to tell the lsp to treat current
   repo with `-mod=vendor`.

For now, we can handle follow scenarios:
 - Repos with neither `go.mod` nor `vendor`.
 - Repos with deps control files, like `vendor.json`.
 - Repos with `go.mod`, actually there is nothing we should do about
   this scenario.

We can't handle follow scenarios:
 - Repos just have `vendor` folder.

Btw, there are several issues when we download the deps.