### PR TITLE
[elastic] Implement full API.

### DIFF
--- a/internal/lsp/elasticext_test.go
+++ b/internal/lsp/elasticext_test.go
@@ -31,6 +31,7 @@ func testLSPExt(t *testing.T, exporter packagestest.Exporter) {
 	// are being executed. If a test is added, this number must be changed.
 	const expectedQNameKindCount = 57
 	const expectedPkgLocatorCount = 2
+	const expectedFullSymbolCount = 14
 
 	files := packagestest.MustCopyFileTree(dir)
 	for fragment, operation := range files {
@@ -77,13 +78,15 @@ func testLSPExt(t *testing.T, exporter packagestest.Exporter) {
 	depsPath := filepath.Join(filepath.Join(goPath, "pkg"), "mod")
 	es := &ElasticServer{*s, depsPath, goRoot}
 
-	expectedQNameKinds := make(qnamekinds)
-	expectedPkgLocators := make(pkgs)
+	expectedQNameKinds := make(QnameKindMap)
+	expectedPkgLocators := make(PkgMap)
+	expectedFullSymbol := make(FullSymMap)
 
 	// Collect any data that needs to be used by subsequent tests.
 	if err := exported.Expect(map[string]interface{}{
 		"packagelocator": expectedPkgLocators.collect,
 		"qnamekind":      expectedQNameKinds.collect,
+		"fullsym":        expectedFullSymbol.collect,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +98,6 @@ func testLSPExt(t *testing.T, exporter packagestest.Exporter) {
 		}
 		expectedQNameKinds.test(t, es)
 	})
-
 	t.Run("PKG", func(t *testing.T) {
 		t.Helper()
 		if len(expectedPkgLocators) != expectedPkgLocatorCount {
@@ -158,6 +160,13 @@ func testLSPExt(t *testing.T, exporter packagestest.Exporter) {
 			}
 		}
 	})
+	t.Run("Full", func(t *testing.T) {
+		t.Helper()
+		if len(expectedFullSymbol) != expectedFullSymbolCount {
+			t.Errorf("got %v full symbols expected %v", len(expectedFullSymbol), expectedFullSymbolCount)
+		}
+		expectedFullSymbol.test(t, es)
+	})
 }
 
 type QNameKindResult struct {
@@ -177,10 +186,25 @@ type NormalizeTuple struct {
 	LocatedDeps bool
 }
 
-type qnamekinds map[protocol.Location]QNameKindResult
-type pkgs map[protocol.Location]PkgResultTuple
+type PackageLocator struct {
+	Version string
+	Name    string
+	RepoURI string
+}
+type DetailSymInfo struct {
+	Name          string
+	Kind          int64
+	ContainerName string
 
-func (qk qnamekinds) test(t *testing.T, s *ElasticServer) {
+	Qname  string
+	PkgLoc PackageLocator
+}
+
+type QnameKindMap map[protocol.Location]QNameKindResult
+type PkgMap map[protocol.Location]PkgResultTuple
+type FullSymMap map[protocol.Location]DetailSymInfo
+
+func (qk QnameKindMap) test(t *testing.T, s *ElasticServer) {
 	for src, target := range qk {
 		params := &protocol.TextDocumentPositionParams{
 			TextDocument: protocol.TextDocumentIdentifier{
@@ -188,27 +212,27 @@ func (qk qnamekinds) test(t *testing.T, s *ElasticServer) {
 			},
 			Position: src.Range.Start,
 		}
-		var locs []protocol.SymbolLocator
+		var symLocators []protocol.SymbolLocator
 		var err error
-		locs, err = s.EDefinition(context.Background(), params)
+		symLocators, err = s.EDefinition(context.Background(), params)
 		if err != nil {
 			t.Fatalf("failed for %v: %v", src, err)
 		}
-		if len(locs) != 1 {
-			t.Errorf("got %d locations for qnamekind, expected 1", len(locs))
+		if len(symLocators) != 1 {
+			t.Errorf("got %d locations for qnamekind, expected 1", len(symLocators))
 		}
 
-		if locs[0].Qname != target.Qname {
-			t.Errorf("Qname: for %v got %v want %v", src, locs[0].Qname, target.Qname)
+		if symLocators[0].Qname != target.Qname {
+			t.Errorf("Qname: for %v got %v want %v", src, symLocators[0].Qname, target.Qname)
 		}
 
-		if locs[0].Kind != protocol.SymbolKind(target.Kind) {
-			t.Errorf("Kind: for %v got %v want %v", src, locs[0].Kind, target.Kind)
+		if symLocators[0].Kind != protocol.SymbolKind(target.Kind) {
+			t.Errorf("Kind: for %v got %v want %v", src, symLocators[0].Kind, target.Kind)
 		}
 	}
 }
 
-func (qk qnamekinds) collect(e *packagestest.Exported, fset *token.FileSet, src packagestest.Range, qname string, kind int64) {
+func (qk QnameKindMap) collect(e *packagestest.Exported, fset *token.FileSet, src packagestest.Range, qname string, kind int64) {
 	sSrc, mSrc := testLocation(e, fset, src)
 	lSrc, err := mSrc.Location(sSrc)
 	if err != nil {
@@ -218,7 +242,7 @@ func (qk qnamekinds) collect(e *packagestest.Exported, fset *token.FileSet, src 
 	qk[lSrc] = QNameKindResult{Qname: qname, Kind: kind}
 }
 
-func (ps pkgs) test(t *testing.T, s *ElasticServer) {
+func (ps PkgMap) test(t *testing.T, s *ElasticServer) {
 	for src, target := range ps {
 		params := &protocol.TextDocumentPositionParams{
 			TextDocument: protocol.TextDocumentIdentifier{
@@ -226,27 +250,27 @@ func (ps pkgs) test(t *testing.T, s *ElasticServer) {
 			},
 			Position: src.Range.Start,
 		}
-		var locs []protocol.SymbolLocator
+		var symLocators []protocol.SymbolLocator
 		var err error
-		locs, err = s.EDefinition(context.Background(), params)
+		symLocators, err = s.EDefinition(context.Background(), params)
 		if err != nil {
 			t.Fatalf("failed for %v: %v", src, err)
 		}
-		if len(locs) != 1 {
-			t.Errorf("got %d locations for package locators, expected 1", len(locs))
+		if len(symLocators) != 1 {
+			t.Errorf("got %d locations for package locators, expected 1", len(symLocators))
 		}
 
-		if locs[0].Package.Name != target.PkgName {
-			t.Errorf("PkgName: for %v got %v want %v", src, locs[0].Package.Name, target.PkgName)
+		if symLocators[0].Package.Name != target.PkgName {
+			t.Errorf("PkgName: for %v got %v want %v", src, symLocators[0].Package.Name, target.PkgName)
 		}
 
-		if locs[0].Package.RepoURI != target.RepoURI {
-			t.Errorf("PkgRepoURI: for %v got %v want %v", src, locs[0].Package.RepoURI, target.RepoURI)
+		if symLocators[0].Package.RepoURI != target.RepoURI {
+			t.Errorf("PkgRepoURI: for %v got %v want %v", src, symLocators[0].Package.RepoURI, target.RepoURI)
 		}
 	}
 }
 
-func (ps pkgs) collect(e *packagestest.Exported, fset *token.FileSet, src packagestest.Range, pkgname, repouri string) {
+func (ps PkgMap) collect(e *packagestest.Exported, fset *token.FileSet, src packagestest.Range, pkgname, repouri string) {
 	sSrc, mSrc := testLocation(e, fset, src)
 	lSrc, err := mSrc.Location(sSrc)
 	if err != nil {
@@ -254,6 +278,83 @@ func (ps pkgs) collect(e *packagestest.Exported, fset *token.FileSet, src packag
 	}
 
 	ps[lSrc] = PkgResultTuple{PkgName: pkgname, RepoURI: repouri}
+}
+
+func (fs FullSymMap) test(t *testing.T, s *ElasticServer) {
+	if len(fs) == 0 {
+		return
+	}
+
+	var result protocol.FullResponse
+	// For now, we just test only source file.
+	for src, _ := range fs {
+		params := &protocol.FullParams{
+			TextDocument: protocol.TextDocumentIdentifier{
+				URI: src.URI,
+			},
+			Reference: false,
+		}
+		var err error
+		result, err = s.Full(context.Background(), params)
+		if err != nil {
+			t.Fatalf("failed for %v: %v", src, err)
+		}
+		break
+	}
+
+	var resultsMap map[float64]protocol.DetailSymbolInformation
+	resultsMap = make(map[float64]protocol.DetailSymbolInformation)
+	// Rearrange the results so we can compare them with test data more easily.
+	for _, result := range result.Symbols {
+		resultsMap[result.Symbol.Location.Range.Start.Line] = result
+	}
+
+	var datasMap map[float64]DetailSymInfo
+	datasMap = make(map[float64]DetailSymInfo)
+	// Rearrange the collect data.
+	for src, data := range fs {
+		datasMap[src.Range.Start.Line] = data
+	}
+
+	for index, _ := range resultsMap {
+		data, ok := datasMap[index]
+		if !ok {
+			t.Errorf("Full Symbol: got unexpected result %v at %v", resultsMap[index], index)
+			continue
+		}
+
+		if data.Name != resultsMap[index].Symbol.Name {
+			t.Errorf("Full Symbol Name: for line %v got %v want %v", index, resultsMap[index].Symbol.Name, datasMap[index].Name)
+		}
+		if protocol.SymbolKind(data.Kind) != resultsMap[index].Symbol.Kind {
+			t.Errorf("Full Symbol Kind: for line %v got %v want %v", index, resultsMap[index].Symbol.Kind, protocol.SymbolKind(datasMap[index].Kind))
+		}
+		if data.ContainerName != resultsMap[index].Symbol.ContainerName {
+			t.Errorf("Full Symbol Container Name: for line %v got %v want %v", index, resultsMap[index].Symbol.ContainerName, datasMap[index].ContainerName)
+		}
+		if data.Qname != resultsMap[index].Qname {
+			t.Errorf("Full Symbol Qname: for line %v got %v want %v", index, resultsMap[index].Qname, datasMap[index].Qname)
+		}
+		if data.PkgLoc.Name != resultsMap[index].Package.Name {
+			t.Errorf("Full Pkg Name: for line %v got %v want %v", index, resultsMap[index].Package.Name, datasMap[index].PkgLoc.Name)
+		}
+		if data.PkgLoc.Version != resultsMap[index].Package.Version {
+			t.Errorf("Full Pkg Version: for line %v got %v want %v", index, resultsMap[index].Package.Version, datasMap[index].PkgLoc.Version)
+		}
+		if data.PkgLoc.RepoURI != resultsMap[index].Package.RepoURI {
+			t.Errorf("Full Pkg RepoURI: for line %v got %v want %v", index, resultsMap[index].Package.RepoURI, datasMap[index].PkgLoc.RepoURI)
+		}
+	}
+}
+
+func (fs FullSymMap) collect(e *packagestest.Exported, fset *token.FileSet, src packagestest.Range, name string, kind int64, containerName, qname, version, pkgName, repoURI string) {
+	sSrc, mSrc := testLocation(e, fset, src)
+	lSrc, err := mSrc.Location(sSrc)
+	if err != nil {
+		return
+	}
+
+	fs[lSrc] = DetailSymInfo{Name: name, Kind: kind, ContainerName: containerName, Qname: qname, PkgLoc: PackageLocator{Version: version, Name: pkgName, RepoURI: repoURI}}
 }
 
 func testLocation(e *packagestest.Exported, fset *token.FileSet, rng packagestest.Range) (span.Span, *protocol.ColumnMapper) {

--- a/internal/lsp/elasticext_test.go
+++ b/internal/lsp/elasticext_test.go
@@ -309,40 +309,40 @@ func (fs FullSymMap) test(t *testing.T, s *ElasticServer) {
 		resultsMap[result.Symbol.Location.Range.Start.Line] = result
 	}
 
-	var datasMap map[float64]DetailSymInfo
-	datasMap = make(map[float64]DetailSymInfo)
-	// Rearrange the collect data.
+	var dataMap map[float64]DetailSymInfo
+	dataMap = make(map[float64]DetailSymInfo)
+	// Rearrange the collected data.
 	for src, data := range fs {
-		datasMap[src.Range.Start.Line] = data
+		dataMap[src.Range.Start.Line] = data
 	}
 
 	for index, _ := range resultsMap {
-		data, ok := datasMap[index]
+		data, ok := dataMap[index]
 		if !ok {
 			t.Errorf("Full Symbol: got unexpected result %v at %v", resultsMap[index], index)
 			continue
 		}
 
 		if data.Name != resultsMap[index].Symbol.Name {
-			t.Errorf("Full Symbol Name: for line %v got %v want %v", index, resultsMap[index].Symbol.Name, datasMap[index].Name)
+			t.Errorf("Full Symbol Name: for line %v got %v want %v", index, resultsMap[index].Symbol.Name, dataMap[index].Name)
 		}
 		if protocol.SymbolKind(data.Kind) != resultsMap[index].Symbol.Kind {
-			t.Errorf("Full Symbol Kind: for line %v got %v want %v", index, resultsMap[index].Symbol.Kind, protocol.SymbolKind(datasMap[index].Kind))
+			t.Errorf("Full Symbol Kind: for line %v got %v want %v", index, resultsMap[index].Symbol.Kind, protocol.SymbolKind(dataMap[index].Kind))
 		}
 		if data.ContainerName != resultsMap[index].Symbol.ContainerName {
-			t.Errorf("Full Symbol Container Name: for line %v got %v want %v", index, resultsMap[index].Symbol.ContainerName, datasMap[index].ContainerName)
+			t.Errorf("Full Symbol Container Name: for line %v got %v want %v", index, resultsMap[index].Symbol.ContainerName, dataMap[index].ContainerName)
 		}
 		if data.Qname != resultsMap[index].Qname {
-			t.Errorf("Full Symbol Qname: for line %v got %v want %v", index, resultsMap[index].Qname, datasMap[index].Qname)
+			t.Errorf("Full Symbol Qname: for line %v got %v want %v", index, resultsMap[index].Qname, dataMap[index].Qname)
 		}
 		if data.PkgLoc.Name != resultsMap[index].Package.Name {
-			t.Errorf("Full Pkg Name: for line %v got %v want %v", index, resultsMap[index].Package.Name, datasMap[index].PkgLoc.Name)
+			t.Errorf("Full Pkg Name: for line %v got %v want %v", index, resultsMap[index].Package.Name, dataMap[index].PkgLoc.Name)
 		}
 		if data.PkgLoc.Version != resultsMap[index].Package.Version {
-			t.Errorf("Full Pkg Version: for line %v got %v want %v", index, resultsMap[index].Package.Version, datasMap[index].PkgLoc.Version)
+			t.Errorf("Full Pkg Version: for line %v got %v want %v", index, resultsMap[index].Package.Version, dataMap[index].PkgLoc.Version)
 		}
 		if data.PkgLoc.RepoURI != resultsMap[index].Package.RepoURI {
-			t.Errorf("Full Pkg RepoURI: for line %v got %v want %v", index, resultsMap[index].Package.RepoURI, datasMap[index].PkgLoc.RepoURI)
+			t.Errorf("Full Pkg RepoURI: for line %v got %v want %v", index, resultsMap[index].Package.RepoURI, dataMap[index].PkgLoc.RepoURI)
 		}
 	}
 }

--- a/internal/lsp/elasticserver.go
+++ b/internal/lsp/elasticserver.go
@@ -96,9 +96,7 @@ func (s *ElasticServer) RunElasticServer(ctx context.Context) error {
 func (s *ElasticServer) ElasticDocumentSymbol(ctx context.Context, params *protocol.DocumentSymbolParams, full bool, pkgLocator *protocol.PackageLocator) (symsInfo []protocol.SymbolInformation,
 	detailSyms []protocol.DetailSymbolInformation,
 	err error) {
-
 	docSyms, err := (*Server).DocumentSymbol(&s.Server, ctx, params)
-
 	var flattenDocumentSymbol func(*[]protocol.DocumentSymbol, string, string)
 	// Note: The reason why we construct the qname during the flatten process is that we can't construct the qname
 	// through the 'SymbolInformation.ContainerName' because of the possibilities of the 'ContainerName' collision.

--- a/internal/lsp/protocol/elasticext.go
+++ b/internal/lsp/protocol/elasticext.go
@@ -1,23 +1,58 @@
 package protocol
 
 type PackageLocator struct {
-	Version string `json:",omitempty"`
-	Name    string
+	Version string `json:"version"`
+	Name    string `json:"name"`
 	RepoURI string `json:"uri"`
 }
 
 // SymbolLocator is the response type for the `textDocument/edefinition` extension.
 type SymbolLocator struct {
 	// The fully qualified name of the symbol.
-	Qname string
+	Qname string `json:"qname"`
 
-	Kind SymbolKind
+	Kind SymbolKind `json:"kind,omitempty"`
 
 	// The file path relative to the repo root URI of the specified symbol.
-	Path string
+	Path string `json:"path"`
 
 	// A concrete location at which the definition is located.
 	Loc Location `json:"location,omitempty"`
 
-	Package PackageLocator
+	Package PackageLocator `json:"package,omitempty"`
+}
+
+type FullParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+	Reference    bool                   `json:"reference"`
+}
+
+type DetailSymbolInformation struct {
+	Symbol SymbolInformation `json:"symbolInformation"`
+	Qname  string            `json:"qname"`
+	// Use for hover
+	// contents MarkupContent MarkedString MarkedString[] `json:"content"`
+	Package PackageLocator `json:"package"`
+}
+
+type ReferenceCategory int
+
+const (
+	UNCATEGORIZED ReferenceCategory = iota
+	READ
+	WRITE
+	INHERIT
+	IMPLEMENT
+)
+
+type Reference struct {
+	Category ReferenceCategory `json:"category"`
+	Loc      Location          `json:"location"`
+	Symbol   SymbolInformation `json:"symbol"`
+	Target   SymbolLocator     `json:"target"`
+}
+
+type FullResponse struct {
+	Symbols    []DetailSymbolInformation `json:"symbols"`
+	References []Reference               `json:"references"`
 }

--- a/internal/lsp/protocol/elasticserver.go
+++ b/internal/lsp/protocol/elasticserver.go
@@ -16,6 +16,8 @@ import (
 type ElasticServer interface {
 	Server
 	EDefinition(context.Context, *TextDocumentPositionParams) ([]SymbolLocator, error)
+	Full(context.Context, *FullParams) (FullResponse, error)
+	ElasticDocumentSymbol(context.Context, *DocumentSymbolParams, bool) ([]SymbolInformation, error, map[Range]string)
 }
 
 func elasticServerHandler(log xlog.Logger, server ElasticServer) jsonrpc2.Handler {
@@ -318,7 +320,7 @@ func elasticServerHandler(log xlog.Logger, server ElasticServer) jsonrpc2.Handle
 				sendParseError(ctx, log, conn, r, err)
 				return
 			}
-			resp, err := server.DocumentSymbol(ctx, &params)
+			resp, err, _ := server.ElasticDocumentSymbol(ctx, &params, false)
 			if err := conn.Reply(ctx, r, resp, err); err != nil {
 				log.Errorf(ctx, "%v", err)
 			}
@@ -369,6 +371,17 @@ func elasticServerHandler(log xlog.Logger, server ElasticServer) jsonrpc2.Handle
 				return
 			}
 			resp, err := server.Formatting(ctx, &params)
+			if err := conn.Reply(ctx, r, resp, err); err != nil {
+				log.Errorf(ctx, "%v", err)
+			}
+		case "textDocument/full": // req
+			var fullParams FullParams
+			if err := json.Unmarshal(*r.Params, &fullParams); err != nil {
+				sendParseError(ctx, log, conn, r, err)
+				return
+			}
+
+			resp, err := server.Full(ctx, &fullParams)
 			if err := conn.Reply(ctx, r, resp, err); err != nil {
 				log.Errorf(ctx, "%v", err)
 			}

--- a/internal/lsp/protocol/elasticserver.go
+++ b/internal/lsp/protocol/elasticserver.go
@@ -17,7 +17,7 @@ type ElasticServer interface {
 	Server
 	EDefinition(context.Context, *TextDocumentPositionParams) ([]SymbolLocator, error)
 	Full(context.Context, *FullParams) (FullResponse, error)
-	ElasticDocumentSymbol(context.Context, *DocumentSymbolParams, bool) ([]SymbolInformation, error, map[Range]string)
+	ElasticDocumentSymbol(context.Context, *DocumentSymbolParams, bool, *PackageLocator) ([]SymbolInformation, []DetailSymbolInformation, error)
 }
 
 func elasticServerHandler(log xlog.Logger, server ElasticServer) jsonrpc2.Handler {
@@ -320,7 +320,7 @@ func elasticServerHandler(log xlog.Logger, server ElasticServer) jsonrpc2.Handle
 				sendParseError(ctx, log, conn, r, err)
 				return
 			}
-			resp, err, _ := server.ElasticDocumentSymbol(ctx, &params, false)
+			resp, _, err := server.ElasticDocumentSymbol(ctx, &params, false, nil)
 			if err := conn.Reply(ctx, r, resp, err); err != nil {
 				log.Errorf(ctx, "%v", err)
 			}

--- a/internal/lsp/testdata/lspext/full/full.go
+++ b/internal/lsp/testdata/lspext/full/full.go
@@ -1,0 +1,96 @@
+package full
+
+import (
+	"fmt"
+)
+
+// FileSymbol          SymbolKind = 1
+// ModuleSymbol        SymbolKind = 2
+// NamespaceSymbol     SymbolKind = 3
+// PackageSymbol       SymbolKind = 4
+// ClassSymbol         SymbolKind = 5
+// MethodSymbol        SymbolKind = 6
+// PropertySymbol      SymbolKind = 7
+// FieldSymbol         SymbolKind = 8
+// ConstructorSymbol   SymbolKind = 9
+// EnumSymbol          SymbolKind = 10
+// InterfaceSymbol     SymbolKind = 11
+// FunctionSymbol      SymbolKind = 12
+// VariableSymbol      SymbolKind = 13
+// ConstantSymbol      SymbolKind = 14
+// StringSymbol        SymbolKind = 15
+// NumberSymbol        SymbolKind = 16
+// BooleanSymbol       SymbolKind = 17
+// ArraySymbol         SymbolKind = 18
+// ObjectSymbol        SymbolKind = 19
+// KeySymbol           SymbolKind = 20
+// NullSymbol          SymbolKind = 21
+// EnumMemberSymbol    SymbolKind = 22
+// StructSymbol        SymbolKind = 23
+// EventSymbol         SymbolKind = 24
+// OperatorSymbol      SymbolKind = 25
+// TypeParameterSymbol SymbolKind = 26
+// Format: fullsym(Location, Name, Kind, ContainerName, Qname, PkgLoc.Version, PkgLoc.Name, PkgLoc.RepoURI)
+
+// Test struct declaration and the field declarations.
+type Circle struct { //@fullsym("cle", "Circle", 23, "", "full.Circle", "", "full", "golang.org/x/tools/internal/lsp/lspext/full")
+	r    float64  //@fullsym("r", "r", 8, "Circle", "full.Circle.r", "", "full", "golang.org/x/tools/internal/lsp/lspext/full")
+	Node struct { //@fullsym("Node", "Node", 8, "Circle", "full.Circle.Node", "", "full", "golang.org/x/tools/internal/lsp/lspext/full")
+		x int
+		y int
+	}
+}
+
+// Test function declaration and variables.
+func func1() int { //@fullsym("c1", "func1", 12, "", "full.func1", "", "full", "golang.org/x/tools/internal/lsp/lspext/full")
+	lhs := 10
+	const rhs int = 20
+	return lhs + rhs
+}
+
+// Test method declaration and field access.
+func (c *Circle) method1() { //@fullsym("method1", "method1", 6, "struct_alias", "full.struct_alias.method1", "", "full", "golang.org/x/tools/internal/lsp/lspext/full")
+	fmt.Print(c.r)
+
+	fmt.Print(c.Node.x)
+}
+
+// Test the interface declaration and method declaration.
+type Shape interface { //@fullsym("ha", "Shape", 11, "", "full.Shape", "", "full", "golang.org/x/tools/internal/lsp/lspext/full")
+	Area() int //@fullsym("Are", "Area", 6, "Shape", "full.Shape.Area", "", "full", "golang.org/x/tools/internal/lsp/lspext/full")
+}
+
+// Test method call and the variabel declaration.
+func func2() { //@fullsym("c", "func2", 12, "", "full.func2", "", "full", "golang.org/x/tools/internal/lsp/lspext/full")
+	var c Circle
+	c.method1()
+}
+
+// Test the struct declared in a function.
+func structInFunc() { //@fullsym("stru", "structInFunc", 12, "", "full.structInFunc", "", "full", "golang.org/x/tools/internal/lsp/lspext/full")
+	type A struct {
+		x int
+		y int
+	}
+
+	a := &A{x: 10, y: 20} //@fullsym("x", "x", 8, "", "full.structInFunc.A.x", "", "full", "golang.org/x/tools/internal/lsp/lspext/full")
+	fmt.Println(a.x, a.y)
+}
+
+// Test the local variable declared in the method declaration.
+func (c Circle) method2() { //@fullsym("me", "method2", 6, "struct_alias", "full.struct_alias.method2", "", "full", "golang.org/x/tools/internal/lsp/lspext/full")
+	num := 10
+	fmt.Println(num)
+}
+
+// Test the variable declared in an anonymous functions case#1.
+func func4() { //@fullsym("func", "func4", 12, "", "full.func4", "", "full", "golang.org/x/tools/internal/lsp/lspext/full")
+	f := func(x int) int {
+		num := 10
+		return x + num
+	}
+	fmt.Println(f(1))
+}
+
+type struct_alias = Circle //@fullsym("str", "struct_alias", 23, "", "full.struct_alias", "", "full", "golang.org/x/tools/internal/lsp/lspext/full")
+type struct_tydef Circle   //@fullsym("tydef", "struct_tydef", 23, "", "full.struct_tydef", "", "full", "golang.org/x/tools/internal/lsp/lspext/full")


### PR DESCRIPTION
The implementation of the full API is based on the 'documentSymbol' API.
However, there are several issues as bellow in the 'documentSymbol'
implementation:
 - 'documentSymbol' API can't provide qname, so we call
   'documentSymbol' first, then iterate the results to compute kind and
   qname for each symbol.
 - 'documentSymbol' API only explore one layer in the subfields of struct.
 - 'documentSymbol' API won't collect the method when it isn't declared
   inside the struct.
 - The results of 'documentSymbol' API are in the hierarchical format.
   We have to flatten it into an array, i.e. SymbolInformation.