### PR TITLE
[elastic] Remove the redundant `ElasticServer.RunElasticServer()` call.

### DIFF
--- a/internal/lsp/elasticserver.go
+++ b/internal/lsp/elasticserver.go
@@ -77,8 +77,6 @@ func RunElasticServerOnAddress(ctx context.Context, cache source.Cache, addr str
 		stream := jsonrpc2.NewHeaderStream(conn, conn)
 		s := NewElasticServer(cache, stream)
 		h(s)
-
-		go s.Run(ctx)
 	}
 }
 


### PR DESCRIPTION
This bug was introduced by upstream, `go s.Run(ctx)` will start another
langserver goroutine while the `h(s)` call has already kicked off the
golang server. The first goroutine will go to sleep with holding the lock 
and wait for the requests to wake up, in contrast, the other goroutine will 
stuck trying to get the lock.

In short, only one golang server goroutine needed here.