### PR TITLE
[elastic] Sync to the upstream

### DIFF
--- a/internal/lsp/cmd/serve.go
+++ b/internal/lsp/cmd/serve.go
@@ -84,13 +84,13 @@ func (s *Serve) Run(ctx context.Context, args ...string) error {
 		go srv.Conn.Run(ctx)
 	}
 	if s.Address != "" {
-		return lsp.RunElasticServerOnAddress(ctx, s.app.Cache, s.Address, run)
+		return lsp.RunElasticServerOnAddress(ctx, s.app.cache, s.Address, run)
 	}
 	if s.Port != 0 {
-		return lsp.RunElasticServerOnPort(ctx, s.app.Cache, s.Port, run)
+		return lsp.RunElasticServerOnPort(ctx, s.app.cache, s.Port, run)
 	}
 	stream := jsonrpc2.NewHeaderStream(os.Stdin, os.Stdout)
-	srv := lsp.NewElasticServer(s.app.Cache, stream)
+	srv := lsp.NewElasticServer(s.app.cache, stream)
 	srv.Conn.Logger = logger(s.Trace, out)
 	return srv.Conn.Run(ctx)
 }

--- a/internal/lsp/elasticext_test.go
+++ b/internal/lsp/elasticext_test.go
@@ -60,7 +60,8 @@ func testLSPExt(t *testing.T, exporter packagestest.Exporter) {
 	log := xlog.New(xlog.StdSink{})
 	cache := cache.New()
 	session := cache.NewSession(log)
-	session.NewView(extViewName, span.FileURI(cfg.Dir), &cfg)
+	view := session.NewView(extViewName, span.FileURI(cfg.Dir))
+	view.SetEnv(cfg.Env)
 	s := &Server{
 		session:     session,
 		undelivered: make(map[span.URI][]source.Diagnostic),
@@ -154,7 +155,7 @@ func testLSPExt(t *testing.T, exporter packagestest.Exporter) {
 				path = filepath.Join(cfg.Dir, v.Path)
 			}
 			pkgLoc := protocol.PackageLocator{RepoURI: v.RepoURI}
-			pathGot := normalizePath(path, cfg, &pkgLoc, es.DepsPath)
+			pathGot := normalizePath(path, cfg.Dir, pkgLoc.RepoURI, es.DepsPath)
 			if pathGot != v.PathWant {
 				t.Errorf("got %v expected %v", pathGot, v.PathWant)
 			}

--- a/internal/lsp/protocol/elasticserver.go
+++ b/internal/lsp/protocol/elasticserver.go
@@ -188,16 +188,6 @@ func elasticServerHandler(log xlog.Logger, server ElasticServer) jsonrpc2.Handle
 			if err := conn.Reply(ctx, r, resp, err); err != nil {
 				log.Errorf(ctx, "%v", err)
 			}
-		case "textDocument/selectionRange": // req
-			var params SelectionRangeParams
-			if err := json.Unmarshal(*r.Params, &params); err != nil {
-				sendParseError(ctx, log, conn, r, err)
-				return
-			}
-			resp, err := server.SelectionRange(ctx, &params)
-			if err := conn.Reply(ctx, r, resp, err); err != nil {
-				log.Errorf(ctx, "%v", err)
-			}
 		case "initialize": // req
 			var params InitializeParams
 			if err := json.Unmarshal(*r.Params, &params); err != nil {


### PR DESCRIPTION
The upstream trims the AST of the dependencies to reduce the memory
usage. That means for the symbol defined in dependencies langserver will
reparse the source files to get the full ASTs, this approach will
introduce overhead for the cross-repo jump.

Upstream has supported the workspace folder change, the `ManageDeps`
should apply to the workspace folder change API to handle the repository
that owns `vendor` file or contains multiple modules.