### PR TITLE
[elastic] Add markup kind `markdown` on go langserver side.

### DIFF
--- a/internal/lsp/protocol/elasticserver.go
+++ b/internal/lsp/protocol/elasticserver.go
@@ -197,6 +197,7 @@ func elasticServerHandler(log xlog.Logger, server ElasticServer) jsonrpc2.Handle
 			if err := server.ManageDeps(&params); err != nil {
 				log.Errorf(ctx, "%v", err)
 			}
+			params.Capabilities.TextDocument.Hover.ContentFormat = append(params.Capabilities.TextDocument.Hover.ContentFormat, "markdown")
 			resp, err := server.Initialize(ctx, &params)
 			if err := conn.Reply(ctx, r, resp, err); err != nil {
 				log.Errorf(ctx, "%v", err)


### PR DESCRIPTION
Given that code server sends `initialize` request without the
`Capabilities.TextDocument` option, in contrast, front-end supports 
`markdown`, add the `markdown` format manually on the go langserver 
side.

For the hover contents contain code snippets, with markdown format, the hover
box as bellow.
<img width="1229" alt="Screen Shot 2019-06-17 at 7 12 27 PM" src="https://user-images.githubusercontent.com/5517506/59600627-50b6e080-9134-11e9-8455-aefb616bec8d.png">
