### PR TITLE
[elastic] Add go ci.

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,0 +1,14 @@
+# $ docker build --fild Dockerfile --tag elastic/go-langserver.
+
+ARG VERSION=1.12-alpine
+FROM golang:${VERSION}
+
+ENV CGO_ENABLED=0
+ENV GO111MODULE=off
+
+WORKDIR /go/src/golang.org/x/tools
+
+RUN apk add --no-cache --quiet make curl git jq unzip tree && \
+    apk add bash && \
+    go get golang.org/x/sync/errgroup
+

--- a/.ci/script/docker/cleanup.sh
+++ b/.ci/script/docker/cleanup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+docker stop $(docker ps -a -q)
+docker rm -v $(docker ps -a -q)
+docker volume prune -f
+
+exit 0

--- a/.ci/script/docker/run_test.sh
+++ b/.ci/script/docker/run_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+docker build --rm -f ".ci/Dockerfile" --build-arg CI_USER_ID=$(id -u) -t code-go-langserver-ci .ci
+
+
+docker run  \
+       --rm \
+       -v $PWD/../tools/:/go/src/golang.org/x/tools code-go-langserver-ci \
+       /bin/bash -c "set -ex
+            go test ./internal/lsp
+       "

--- a/internal/lsp/elasticext_test.go
+++ b/internal/lsp/elasticext_test.go
@@ -29,7 +29,7 @@ func testLSPExt(t *testing.T, exporter packagestest.Exporter) {
 
 	// We hardcode the expected number of test cases to ensure that all tests
 	// are being executed. If a test is added, this number must be changed.
-	const expectedQNameKindCount = 57
+	const expectedQNameKindCount = 59
 	const expectedPkgLocatorCount = 2
 	const expectedFullSymbolCount = 14
 
@@ -285,7 +285,6 @@ func (fs FullSymMap) test(t *testing.T, s *ElasticServer) {
 	if len(fs) == 0 {
 		return
 	}
-
 	var result protocol.FullResponse
 	// For now, we just test only source file.
 	for src, _ := range fs {

--- a/internal/lsp/testdata/lspext/edefinition/packagelocator.go
+++ b/internal/lsp/testdata/lspext/edefinition/packagelocator.go
@@ -2,13 +2,11 @@ package edefinition
 
 import (
 	"fmt"
-
-	"golang.org/x/tools/internal/jsonrpc2"
 )
 
 // There is a bug in this test framework that it can't get the identifier from the imports nonofficial package in the
 // test process. Like can get the identifier 'Println' from "fmt", but can't get the identifier 'Direction' from 'jsonrpc2'.
 func pkgloc() { //@packagelocator("loc", "edefinition", "golang.org/x/tools/internal/lsp/lspext/edefinition")
-	var d jsonrpc2.Direction // @packagelocator("Dir", "jsonrpc2", "golang.org/x/tools/internal/jsonrpc2")
-	fmt.Println(d.String())  //@packagelocator("rintln", "fmt", "fmt")
+	// var d jsonrpc2.Direction
+	fmt.Println(0) //@packagelocator("rintln", "fmt", "fmt")
 }

--- a/internal/lsp/testdata/lspext/edefinition/qnamekind.go
+++ b/internal/lsp/testdata/lspext/edefinition/qnamekind.go
@@ -51,7 +51,7 @@ func func1() int { //@qnamekind("c1", "edefinition.func1", 12)
 }
 
 // Test method declaration and field access.
-func (c *Circle) method1() { //edefinition("method1", "edefinition.Circle.method1", 6)
+func (c *Circle) method1() { //@qnamekind("method1", "edefinition.Circle.method1", 6)
 	fmt.Print(c.r) //@qnamekind("fmt", "fmt", 4),qnamekind("Pri", "fmt.Print", 12)
 
 	fmt.Print(c.Node.x) //@qnamekind("No", "edefinition.Circle.Node", 8)
@@ -168,7 +168,7 @@ func func8(pair struct {
 }
 
 // Test the field symbol in an anonymous type case#3
-func func9(x int, y int) (pair struct { //@edefinition("x", "edefinition.func9.x", 13)
+func func9(x int, y int) (pair struct { //@qnamekind("x", "edefinition.func9.x", 13)
 	x int //@qnamekind("x", "edefinition.func9.pair.x", 8)
 	y int
 }) {


### PR DESCRIPTION
For now, the docker file and the script are only used for the unit test. Once
the go language server ready to be released, we should add the package 
script and enrich the docker file.

The fact I want to emphasize here is that go langserver rely on
unfinished gopls, which located in the `internal` folder. That's why the
go langserver based on the whole `tools` repo. Once the gopls finished,
we should refactor the functionality we added.